### PR TITLE
Solution for Simple service to store e-learning course status data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+target/
+!.mvn/wrapper/maven-wrapper.jar
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+nbproject/private/
+build/
+nbbuild/
+dist/
+nbdist/
+.nb-gradle/

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>com.lginterview</groupId>
+	<artifactId>courseservice</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<packaging>jar</packaging>
+
+	<name>courseservice</name>
+	<description>Solution for lg interview 26092017</description>
+
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>1.5.7.RELEASE</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<java.version>1.8</java.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.module</groupId>
+			<artifactId>jackson-module-parameter-names</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.datatype</groupId>
+			<artifactId>jackson-datatype-jdk8</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.datatype</groupId>
+			<artifactId>jackson-datatype-jsr310</artifactId>
+		</dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>19.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.flextrade.jfixture</groupId>
+            <artifactId>jfixture</artifactId>
+            <version>2.6.3</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+
+</project>

--- a/src/main/java/com/lginterview/CourseServiceApplication.java
+++ b/src/main/java/com/lginterview/CourseServiceApplication.java
@@ -1,0 +1,12 @@
+package com.lginterview;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class CourseServiceApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(CourseServiceApplication.class, args);
+    }
+}

--- a/src/main/java/com/lginterview/common/CourseFunction.java
+++ b/src/main/java/com/lginterview/common/CourseFunction.java
@@ -1,0 +1,8 @@
+package com.lginterview.common;
+
+import com.lginterview.exceptions.CourseDataRetrievalException;
+
+@FunctionalInterface
+public interface CourseFunction<T, R> {
+    R apply(T t) throws CourseDataRetrievalException;
+}

--- a/src/main/java/com/lginterview/controllers/CourseController.java
+++ b/src/main/java/com/lginterview/controllers/CourseController.java
@@ -1,0 +1,36 @@
+package com.lginterview.controllers;
+
+import com.lginterview.dto.CourseRequest;
+import com.lginterview.dto.CourseStatus;
+import com.lginterview.exceptions.CourseDataRetrievalException;
+import com.lginterview.providers.CourseProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+public class CourseController {
+
+    private final CourseProvider courseProvider;
+
+    @Autowired
+    public CourseController(CourseProvider courseProvider) {
+        this.courseProvider = courseProvider;
+    }
+
+    @RequestMapping(path = "/status/course", method = RequestMethod.POST)
+    public ResponseEntity<Long> modifyCourse(@RequestBody @Validated CourseRequest courseRequest)
+            throws CourseDataRetrievalException {
+        return new ResponseEntity<>(courseProvider.modifyCourse(courseRequest), HttpStatus.OK);
+    }
+
+    @RequestMapping(path = "/session/user/{userId}/course/{coursesId}/state", method = RequestMethod.GET)
+    public ResponseEntity<CourseStatus> getCourseStatus(@PathVariable("userId" ) long userId,
+                                                        @PathVariable("coursesId") long coursesId)
+            throws CourseDataRetrievalException {
+        CourseStatus courseStatus = courseProvider.getCourseStatus(userId, coursesId);
+        return new ResponseEntity<>(courseStatus, HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/lginterview/dto/CourseRequest.java
+++ b/src/main/java/com/lginterview/dto/CourseRequest.java
@@ -1,0 +1,54 @@
+package com.lginterview.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.validation.constraints.NotNull;
+import java.time.ZonedDateTime;
+
+public class CourseRequest {
+
+    private final long userId;
+    private final long courseId;
+    private final RequestType type;
+    private final Integer score;
+    private final ZonedDateTime timestamp;
+
+    public CourseRequest(@JsonProperty(value = "userId", required = true) long userId,
+                         @JsonProperty(value = "courseId", required = true) long courseId,
+                         @JsonProperty(value = "type", required = true) RequestType type,
+                         @JsonProperty("score") Integer score,
+                         @JsonProperty(value = "timestamp", required = true) ZonedDateTime timestamp) {
+
+        this.userId = userId;
+        this.courseId = courseId;
+        this.type = type;
+        this.score = score;
+        this.timestamp = timestamp;
+    }
+
+    @NotNull
+    public long getUserId() {
+        return userId;
+    }
+
+    @NotNull
+    public long getCourseId() {
+        return courseId;
+    }
+
+    @NotNull
+    public RequestType getType() {
+        return type;
+    }
+
+    public Integer getScore() {
+        return score;
+    }
+
+    @NotNull
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern ="yyyy-MM-dd[[ ]['T']HH:mm:ss.SSSSSSxxx")
+    public ZonedDateTime getTimestamp() {
+        return timestamp;
+    }
+}

--- a/src/main/java/com/lginterview/dto/CourseStatus.java
+++ b/src/main/java/com/lginterview/dto/CourseStatus.java
@@ -1,0 +1,83 @@
+package com.lginterview.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.ZonedDateTime;
+
+public class CourseStatus {
+
+    private final ZonedDateTime startedDate;
+    private final int totalSessionTime;
+    private final ZonedDateTime endDate;
+    private final int bestScore;
+    private final int averageScore;
+
+    public CourseStatus(@JsonProperty(value = "started_date", required = true)
+                        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss.SSSSSSxxx")
+                                ZonedDateTime startedDate,
+                        @JsonProperty("total_session_time") int totalSessionTime,
+                        @JsonProperty("end_date")
+                        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss.SSSSSSxxx")
+                                ZonedDateTime endDate,
+                        @JsonProperty("best_score") int bestScore,
+                        @JsonProperty("average_score") int averageScore) {
+
+        this.startedDate = startedDate;
+        this.totalSessionTime = totalSessionTime;
+        this.endDate = endDate;
+        this.bestScore = bestScore;
+        this.averageScore = averageScore;
+    }
+
+    @JsonProperty("started_date")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss.SSSSSSxxx")
+    public ZonedDateTime getStartedDate() {
+        return startedDate;
+    }
+
+    @JsonProperty("total_session_time")
+    public int getTotalSessionTime() {
+        return totalSessionTime;
+    }
+
+    @JsonProperty("end_date")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss.SSSSSSxxx")
+    public ZonedDateTime getEndDate() {
+        return endDate;
+    }
+
+    @JsonProperty("best_score")
+    public int getBestScore() {
+        return bestScore;
+    }
+
+    @JsonProperty("average_score")
+    public int getAverageScore() {
+        return averageScore;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        CourseStatus that = (CourseStatus) o;
+
+        if (totalSessionTime != that.totalSessionTime) return false;
+        if (bestScore != that.bestScore) return false;
+        if (averageScore != that.averageScore) return false;
+        if (startedDate != null ? !startedDate.equals(that.startedDate) : that.startedDate != null) return false;
+        return endDate != null ? endDate.equals(that.endDate) : that.endDate == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = startedDate != null ? startedDate.hashCode() : 0;
+        result = 31 * result + totalSessionTime;
+        result = 31 * result + (endDate != null ? endDate.hashCode() : 0);
+        result = 31 * result + bestScore;
+        result = 31 * result + averageScore;
+        return result;
+    }
+}

--- a/src/main/java/com/lginterview/dto/RequestType.java
+++ b/src/main/java/com/lginterview/dto/RequestType.java
@@ -1,0 +1,12 @@
+package com.lginterview.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum RequestType {
+    @JsonProperty("init")
+    INIT,
+    @JsonProperty("save")
+    SAVE,
+    @JsonProperty("finish")
+    FINISH
+}

--- a/src/main/java/com/lginterview/entities/Course.java
+++ b/src/main/java/com/lginterview/entities/Course.java
@@ -1,0 +1,62 @@
+package com.lginterview.entities;
+
+import javax.persistence.*;
+
+import java.time.ZonedDateTime;
+import java.util.LinkedList;
+import java.util.List;
+
+@Entity
+public class Course {
+
+    @Id
+    @GeneratedValue
+    private long Id;
+
+    private ZonedDateTime startDate;
+    private ZonedDateTime endDate;
+
+    @ElementCollection
+    @CollectionTable(name = "scores")
+    private final List<Integer> scores = new LinkedList<>();
+
+    @ManyToOne(targetEntity = User.class)
+    private User courseUser;
+
+    public long getId() {
+        return Id;
+    }
+
+    public void setId(long id) {
+        Id = id;
+    }
+
+    public ZonedDateTime getStartDate() {
+        return startDate;
+    }
+
+    public void setStartDate(ZonedDateTime startDate) {
+        this.startDate = startDate;
+    }
+
+    public ZonedDateTime getEndDate() {
+        return endDate;
+    }
+
+    public void setEndDate(ZonedDateTime endDate) {
+        this.endDate = endDate;
+    }
+
+    public List<Integer>getScores() {
+        return scores;
+    }
+
+    public User getCourseUser() {
+        return courseUser;
+    }
+
+    public void setCourseUser(User courseUser) {
+        this.courseUser = courseUser;
+    }
+
+}

--- a/src/main/java/com/lginterview/entities/User.java
+++ b/src/main/java/com/lginterview/entities/User.java
@@ -1,0 +1,19 @@
+package com.lginterview.entities;
+
+import javax.persistence.*;
+
+@Entity
+public class User {
+
+    @Id
+    @GeneratedValue
+    private long Id;
+
+    public long getId() {
+        return Id;
+    }
+
+    public void setId(long id) {
+        Id = id;
+    }
+}

--- a/src/main/java/com/lginterview/exceptions/ApiExceptionHandler.java
+++ b/src/main/java/com/lginterview/exceptions/ApiExceptionHandler.java
@@ -1,0 +1,42 @@
+package com.lginterview.exceptions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import javax.servlet.http.HttpServletResponse;
+
+@ControllerAdvice
+public class ApiExceptionHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(ApiExceptionHandler.class);
+
+    @ExceptionHandler(value = {CourseDataRetrievalException.class})
+    public void dataRetrievalException(CourseDataRetrievalException e, HttpServletResponse response) {
+        try {
+            response.sendError(HttpServletResponse.SC_NOT_FOUND);
+        } catch (Exception se) {
+            logger.error("Exception sending error response:", se);
+        }
+    }
+
+    @ExceptionHandler(value = {IllegalArgumentException.class})
+    public void validationException(IllegalArgumentException e, HttpServletResponse response) {
+        try {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+        } catch (Exception se) {
+            logger.error("Exception sending error response:", se);
+        }
+    }
+
+    @ExceptionHandler(value = {Exception.class})
+    public void generalException(HttpServletResponse response, Exception e) {
+        try {
+            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        } catch (Exception se) {
+            logger.error("Exception sending error response:", se);
+        }
+    }
+}
+

--- a/src/main/java/com/lginterview/exceptions/CourseDataRetrievalException.java
+++ b/src/main/java/com/lginterview/exceptions/CourseDataRetrievalException.java
@@ -1,0 +1,8 @@
+package com.lginterview.exceptions;
+
+public class CourseDataRetrievalException extends Exception {
+
+    public CourseDataRetrievalException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/lginterview/filter/ThrottlingFilter.java
+++ b/src/main/java/com/lginterview/filter/ThrottlingFilter.java
@@ -1,0 +1,67 @@
+package com.lginterview.filter;
+
+import com.google.common.util.concurrent.RateLimiter;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class ThrottlingFilter implements Filter {
+
+    private final String limitationPath;
+    private final RateLimiter rateLimiter;
+    private final String limitMessage;
+
+    @Autowired
+    public ThrottlingFilter(@Value("${courseservice.limitation-path}") String limitationPath,
+                            @Value("${courseservice.limitation-count}") int limitationCount,
+                            @Value("${courseservice.limitation-message}") String limitMessage) {
+        this.limitationPath = limitationPath;
+        this.rateLimiter = RateLimiter.create(limitationCount);
+        this.limitMessage = limitMessage;
+    }
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
+            throws IOException, ServletException {
+
+        if (!(servletRequest instanceof HttpServletRequest) ||
+                !(servletResponse instanceof HttpServletResponse)) {
+            throw new ServletException("Only http requests are supported ");
+        }
+
+        internalDoFilter((HttpServletRequest) servletRequest, (HttpServletResponse) servletResponse, filterChain);
+    }
+
+    private void internalDoFilter(HttpServletRequest servletRequest,
+                                  HttpServletResponse servletResponse,
+                                  FilterChain filterChain)
+            throws IOException, ServletException {
+
+        if (servletRequest.getRequestURI().contains(limitationPath)) {
+            if (!rateLimiter.tryAcquire()) {
+                servletResponse.reset();
+                servletResponse.sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE, limitMessage);
+                return;
+            }
+        }
+        filterChain.doFilter(servletRequest, servletResponse);
+    }
+
+    @Override
+    public void destroy() {
+
+    }
+}

--- a/src/main/java/com/lginterview/providers/CourseProvider.java
+++ b/src/main/java/com/lginterview/providers/CourseProvider.java
@@ -1,0 +1,11 @@
+package com.lginterview.providers;
+
+import com.lginterview.dto.CourseRequest;
+import com.lginterview.dto.CourseStatus;
+import com.lginterview.exceptions.CourseDataRetrievalException;
+
+public interface CourseProvider {
+    Long modifyCourse(CourseRequest courseRequest) throws CourseDataRetrievalException;
+
+    CourseStatus getCourseStatus(long userId, long courseId) throws CourseDataRetrievalException;
+}

--- a/src/main/java/com/lginterview/providers/CourseProviderImpl.java
+++ b/src/main/java/com/lginterview/providers/CourseProviderImpl.java
@@ -1,0 +1,139 @@
+package com.lginterview.providers;
+
+import com.lginterview.common.CourseFunction;
+import com.lginterview.dto.CourseRequest;
+import com.lginterview.dto.CourseStatus;
+import com.lginterview.dto.RequestType;
+import com.lginterview.entities.Course;
+import com.lginterview.entities.User;
+import com.lginterview.exceptions.CourseDataRetrievalException;
+import com.lginterview.repositories.CourseRepository;
+import com.lginterview.repositories.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.*;
+
+@Service
+public class CourseProviderImpl implements CourseProvider {
+
+    private final CourseRepository courseRepository;
+    private final UserRepository userRepository;
+    private final Map<RequestType, CourseFunction<CourseRequest, Long>> courseActions = new HashMap<>();
+
+    @Autowired
+    public CourseProviderImpl(CourseRepository courseRepository, UserRepository userRepository) {
+        this.courseRepository = courseRepository;
+        this.userRepository = userRepository;
+
+        this.courseActions.put(RequestType.INIT, (this::createCourse));
+        this.courseActions.put(RequestType.SAVE, (this::updateCourse));
+        this.courseActions.put(RequestType.FINISH, (this::closeCourse));
+    }
+
+    @Override
+    @Transactional
+    public Long modifyCourse(CourseRequest courseRequest) throws CourseDataRetrievalException {
+        if (courseRequest == null)
+            throw new IllegalArgumentException("Course Request cannot be null");
+
+        if (courseRequest.getType() == null)
+            throw new IllegalArgumentException("Course Request Type cannot be null");
+
+        if (courseActions.containsKey(courseRequest.getType()))
+            return courseActions.get(courseRequest.getType()).apply(courseRequest);
+        else
+            throw new IllegalArgumentException("Invalid Course Request type");
+    }
+
+    private Long createCourse(CourseRequest courseRequest) throws CourseDataRetrievalException {
+        Course newCourse = courseRepository.findOne(courseRequest.getCourseId());
+        if (newCourse != null)
+            return newCourse.getId();
+
+        User courseUser = userRepository.findOne(courseRequest.getUserId());
+        if (courseUser == null)
+            throw new CourseDataRetrievalException("User not found");
+
+        newCourse = new Course();
+        newCourse.setStartDate(courseRequest.getTimestamp());
+        newCourse.setCourseUser(courseUser);
+        return courseRepository.save(newCourse).getId();
+    }
+
+    private Long updateCourse(CourseRequest courseRequest) throws CourseDataRetrievalException {
+
+        Course courseToUpdate = courseRepository.findOne(courseRequest.getCourseId());
+        if (courseToUpdate == null)
+            throw new CourseDataRetrievalException("Course Not Found");
+
+        if (courseRequest.getScore() != null) {
+            int scoreValue = courseRequest.getScore();
+            courseToUpdate.getScores().add(scoreValue);
+            courseRepository.save(courseToUpdate);
+        }
+        return courseToUpdate.getId();
+    }
+
+    private Long closeCourse(CourseRequest courseRequest) throws CourseDataRetrievalException {
+        Course courseToClose = courseRepository.findOne(courseRequest.getCourseId());
+        if (courseToClose == null)
+            throw new CourseDataRetrievalException("Course Not Found");
+
+        courseToClose.setEndDate(courseRequest.getTimestamp());
+        courseRepository.save(courseToClose);
+        return courseToClose.getId();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public CourseStatus getCourseStatus(long userId, long courseId) throws CourseDataRetrievalException {
+
+        Course courseData = getCourse(userId, courseId);
+
+        int bestScore = 0;
+        int averageScore = 0;
+
+        if ((courseData.getScores() != null)) {
+            bestScore = courseData.getScores()
+                    .stream()
+                    .mapToInt(score -> score)
+                    .max()
+                    .orElse(0);
+
+            averageScore = (int) courseData.getScores()
+                    .stream()
+                    .mapToInt(score -> score)
+                    .average()
+                    .orElse(0.0);
+        }
+
+        int courseTime = 0;
+        if (courseData.getEndDate() != null)
+            courseTime = (int) (courseData.getEndDate().toEpochSecond() - courseData.getStartDate().toEpochSecond());
+
+        ZonedDateTime utcStartTime=getUTCDateTime(courseData.getStartDate());
+        ZonedDateTime utcEndTime=getUTCDateTime(courseData.getEndDate());
+        return new CourseStatus(utcStartTime, courseTime,utcEndTime, bestScore, averageScore);
+    }
+
+    private Course getCourse(long userId, long courseId) throws CourseDataRetrievalException {
+        Optional<Course> matchingCourse = courseRepository.getCourse(userId, courseId);
+
+        if (!matchingCourse.isPresent())
+            throw new CourseDataRetrievalException("Course Not Found");
+
+        return matchingCourse.get();
+    }
+
+    private ZonedDateTime getUTCDateTime(ZonedDateTime zonedDateTime)
+    {
+        if(zonedDateTime==null)
+            return null;
+        return zonedDateTime.withZoneSameInstant(ZoneId.of("UTC"));
+    }
+
+}

--- a/src/main/java/com/lginterview/repositories/CourseRepository.java
+++ b/src/main/java/com/lginterview/repositories/CourseRepository.java
@@ -1,0 +1,15 @@
+package com.lginterview.repositories;
+
+import com.lginterview.entities.Course;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface CourseRepository extends CrudRepository<Course, Long> {
+
+    @Query(value = "SELECT c from Course c where c.courseUser.Id=:userId and c.Id=:courseId")
+    Optional<Course> getCourse(@Param("userId") long userId, @Param("courseId") long courseId);
+
+}

--- a/src/main/java/com/lginterview/repositories/UserRepository.java
+++ b/src/main/java/com/lginterview/repositories/UserRepository.java
@@ -1,0 +1,9 @@
+package com.lginterview.repositories;
+
+import com.lginterview.entities.User;
+import org.springframework.data.repository.CrudRepository;
+
+
+public interface UserRepository extends CrudRepository<User, Long> {
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,17 @@
+#Persistence Configuration
+spring.datasource.url=jdbc:h2:mem:courses
+spring.datasource.username=admin
+spring.datasource.password=
+spring.datasource.driver-class-name=org.h2.Driver
+spring.jpa.show-sql = true
+spring.jpa.hibernate.ddl-auto = create-drop
+spring.jpa.hibernate.naming-strategy = org.hibernate.cfg.ImprovedNamingStrategy
+spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.H2Dialect
+
+#Jackson Configuration
+spring.jackson.serialization.write-dates-as-timestamps=false
+
+#Application Configuration
+courseservice.limitation-path=/status/course
+courseservice.limitation-count=5
+courseservice.limitation-message=Request Limit Reached

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -1,0 +1,3 @@
+insert INTO user(id) VALUES (1);
+insert INTO user(id) VALUES (2);
+insert INTO user(id) VALUES (3);

--- a/src/test/java/com/lginterview/filter/ThrottlingFilterTest.java
+++ b/src/test/java/com/lginterview/filter/ThrottlingFilterTest.java
@@ -1,0 +1,102 @@
+package com.lginterview.filter;
+
+import com.flextrade.jfixture.JFixture;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class ThrottlingFilterTest {
+
+    private final JFixture fixture = new JFixture();
+    private String limitMessage;
+    private String path;
+    private ThrottlingFilter throttlingFilter;
+    private HttpServletRequest httpServletRequest;
+    private HttpServletResponse httpServletResponse;
+    private FilterChain filterChain;
+
+    @Before
+    public void setUp() throws Exception {
+        limitMessage = fixture.create(String.class);
+        path = fixture.create(String.class);
+        throttlingFilter = new ThrottlingFilter(path, 1, limitMessage);
+        httpServletRequest = mock(HttpServletRequest.class);
+        httpServletResponse = mock(HttpServletResponse.class);
+        filterChain = mock(FilterChain.class);
+    }
+
+    @Test
+    public void Given_NotMatchingPath_When_doFilter_Then_RequestIsPassed()
+            throws IOException, ServletException {
+        //arrange
+        given(httpServletRequest.getRequestURI()).willReturn(fixture.create(String.class));
+
+        //act
+        throttlingFilter.doFilter(httpServletRequest, httpServletResponse, filterChain);
+
+        //assert
+        verify(filterChain, times(1)).doFilter(httpServletRequest, httpServletResponse);
+    }
+
+    @Test
+    public void Given_MatchingPathAndLimitNotReached_When_doFilter_Then_RequestIsPassed()
+            throws IOException, ServletException {
+        //arrange
+        given(httpServletRequest.getRequestURI()).willReturn(path);
+
+        //act
+        throttlingFilter.doFilter(httpServletRequest, httpServletResponse, filterChain);
+
+        //assert
+        verify(filterChain, times(1)).doFilter(httpServletRequest, httpServletResponse);
+    }
+
+    @Test
+    public void Given_MatchingPathAndLimitReached_When_doFilter_Then_RequestIsBlocked()
+            throws IOException, ServletException {
+        //arrange
+        given(httpServletRequest.getRequestURI()).willReturn(path);
+
+        //act
+        throttlingFilter.doFilter(httpServletRequest, httpServletResponse, filterChain);
+        throttlingFilter.doFilter(httpServletRequest, httpServletResponse, filterChain);
+
+        //assert
+        verify(filterChain, times(1)).doFilter(httpServletRequest, httpServletResponse);
+        verify(httpServletResponse, times(1))
+                .sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE, limitMessage);
+    }
+
+    @Test(expected = ServletException.class)
+    public void Given_NonHttpRequest_When_doFilter_Then_ExceptionIsThrown()
+            throws IOException, ServletException {
+        //arrange
+        ServletRequest servletRequest = mock(ServletRequest.class);
+
+        //act
+        throttlingFilter.doFilter(servletRequest, httpServletResponse, filterChain);
+    }
+
+    @Test(expected = ServletException.class)
+    public void Given_NonHttpResponse_When_doFilter_Then_ExceptionIsThrown()
+            throws IOException, ServletException {
+        //arrange
+        ServletResponse servletResponse = mock(ServletResponse.class);
+
+        //act
+        throttlingFilter.doFilter(httpServletRequest, servletResponse, filterChain);
+    }
+}

--- a/src/test/java/com/lginterview/integration/CourseApiTests.java
+++ b/src/test/java/com/lginterview/integration/CourseApiTests.java
@@ -1,0 +1,217 @@
+package com.lginterview.integration;
+
+
+import com.flextrade.jfixture.JFixture;
+import com.lginterview.CourseServiceApplication;
+import com.lginterview.dto.CourseStatus;
+import com.lginterview.entities.Course;
+import com.lginterview.entities.User;
+import com.lginterview.repositories.CourseRepository;
+import com.lginterview.repositories.UserRepository;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
+        classes = CourseServiceApplication.class)
+@AutoConfigureTestDatabase
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+public class CourseApiTests {
+
+    @Autowired
+    private TestRestTemplate template;
+    @Autowired
+    private CourseRepository courseRepository;
+    @Autowired
+    private UserRepository userRepository;
+    private HttpHeaders headers;
+    private final JFixture fixture = new JFixture();
+
+    @Before
+    public void setUp() throws Exception {
+        headers = new HttpHeaders();
+        headers.add("Content-Type", "application/json");
+    }
+
+    @Test
+    public void Given_CourseCreateRequest_When_requestCourseModification_Then_CourseIsCreated() {
+        //arrange
+        String newCourseRequest = "{\"userId\":\"1\",\"courseId\":\"22\",\"type\":\"init\"," +
+                "\"timestamp\" :\"2017-06-28 14:21:45.375193+03:00\"}";
+
+        //act
+        ResponseEntity<Long> newCourseResponse =
+                template.postForEntity(
+                        "/status/course",
+                        new HttpEntity<>(newCourseRequest, headers),
+                        Long.class);
+
+        //assert
+        assertNotNull(newCourseResponse);
+        assertEquals(HttpStatus.OK, newCourseResponse.getStatusCode());
+        assertEquals(1L, newCourseResponse.getBody().longValue());
+    }
+
+    @Test
+    public void Given_CourseSaveRequestForExistingCourse_When_requestCourseModification_Then_CourseIsUpdated() {
+        //arrange
+        Course newCourse = new Course();
+        long newCourseId = courseRepository.save(newCourse).getId();
+
+        String courseSaveRequest = "{\"userId\":\"1\",\"courseId\":\"" + Long.toString(newCourseId) +
+                "\",\"type\":\"save\"," +
+                "\"score\":\"45\",\"timestamp\" :\"2017-06-28T14:21:45.375193+03:00\"}";
+
+        //act
+        ResponseEntity<Long> courseSaveResponse =
+                template.postForEntity(
+                        "/status/course",
+                        new HttpEntity<>(courseSaveRequest, headers),
+                        Long.class);
+
+        //assert
+        assertNotNull(courseSaveResponse);
+        assertEquals(HttpStatus.OK, courseSaveResponse.getStatusCode());
+        assertEquals(newCourseId, courseSaveResponse.getBody().longValue());
+    }
+
+    @Test
+    public void Given_CourseSaveRequestForNotExistingCourse_When_requestCourseModification_Then_NotFoundIsReturned() {
+        //arrange
+        String courseSaveRequest = "{\"userId\":\"1\",\"courseId\":\"23\",\"type\":\"save\"," +
+                "\"score\":\"45\",\"timestamp\" :\"2017-06-28 14:21:45.375193+03:00\"}";
+
+        //act
+        ResponseEntity<String> courseSaveResponse =
+                template.postForEntity(
+                        "/status/course",
+                        new HttpEntity<>(courseSaveRequest, headers),
+                        String.class);
+
+        //assert
+        assertNotNull(courseSaveResponse);
+        assertEquals(HttpStatus.NOT_FOUND, courseSaveResponse.getStatusCode());
+    }
+
+    @Test
+    public void Given_CourseFinishRequestForExistingCourse_When_requestCourseModification_Then_CourseIsFinished() {
+        //arrange
+        Course newCourse = new Course();
+        long newCourseId = courseRepository.save(newCourse).getId();
+
+        String courseSaveRequest = "{\"userId\":\"1\",\"courseId\":\"" + Long.toString(newCourseId) +
+                "\",\"type\":\"finish\"," +
+                "\"score\":\"45\",\"timestamp\" :\"2017-06-28T14:21:45.375193+03:00\"}";
+
+        //act
+        ResponseEntity<Long> courseFinishResponse =
+                template.postForEntity(
+                        "/status/course",
+                        new HttpEntity<>(courseSaveRequest, headers),
+                        Long.class);
+
+        //assert
+        assertNotNull(courseFinishResponse);
+        assertEquals(HttpStatus.OK, courseFinishResponse.getStatusCode());
+        assertEquals(newCourseId, courseFinishResponse.getBody().longValue());
+    }
+
+    @Test
+    public void Given_CourseFinishRequestForNotExistingCourse_When_requestCourseModification_Then_NotFoundIsReturned() {
+        //arrange
+        String courseSaveRequest = "{\"userId\":\"1\",\"courseId\":\"23\",\"type\":\"finish\"," +
+                "\"score\":\"45\",\"timestamp\" :\"2017-06-28 14:21:45.375193+03:00\"}";
+
+        //act
+        ResponseEntity<String> courseFinishResponse =
+                template.postForEntity(
+                        "/status/course",
+                        new HttpEntity<>(courseSaveRequest, headers),
+                        String.class);
+
+        //assert
+        assertNotNull(courseFinishResponse);
+        assertEquals(HttpStatus.NOT_FOUND, courseFinishResponse.getStatusCode());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void Given_CourseStatusRequestForExistingCourse_When_requestCourseStatus_Then_StatusIsReturned() {
+        //arrange
+        List<Integer> scores = fixture.collections().createCollection(List.class, Integer.class);
+
+        User user = userRepository.findOne(1L);
+
+        Course newCourse = getNewCourse(scores, user);
+        long newCourseId = courseRepository.save(newCourse).getId();
+
+        int expectedBestScore = scores.stream().mapToInt(score -> score).max().orElse(0);
+        int expectedAverageScore = (int) scores.stream().mapToInt(score -> score).average().orElse(0.0);
+        int expectedCourseTime =
+                (int) ((newCourse.getEndDate().toEpochSecond() - newCourse.getStartDate().toEpochSecond()));
+
+        CourseStatus expectedCourseStatus =
+                new CourseStatus(newCourse.getStartDate().withZoneSameInstant(ZoneId.of("UTC")),
+                        expectedCourseTime,
+                        newCourse.getEndDate().withZoneSameInstant(ZoneId.of("UTC")),
+                        expectedBestScore,
+                        expectedAverageScore);
+
+        String courseStatusPath = "/session/user/1/course/" + Long.toString(newCourseId) + "/state";
+
+        //act
+        ResponseEntity<CourseStatus> courseStatusResponse =
+                template.getForEntity(
+                        courseStatusPath,
+                        CourseStatus.class);
+
+        //assert
+        assertNotNull(courseStatusResponse);
+        assertEquals(HttpStatus.OK, courseStatusResponse.getStatusCode());
+
+        CourseStatus returnedCourseStatus = courseStatusResponse.getBody();
+        assertEquals(expectedCourseStatus, returnedCourseStatus);
+    }
+
+    private Course getNewCourse(List<Integer> scores, User user) {
+        Course newCourse = new Course();
+        newCourse.setCourseUser(user);
+        newCourse.setStartDate(ZonedDateTime.now());
+        newCourse.setEndDate(ZonedDateTime.now());
+        newCourse.getScores().addAll(scores);
+        return newCourse;
+    }
+
+    @Test
+    public void Given_CourseStatusRequestForNotExistingCourse_When_requestCourseStatus_Then_NotFoundIsReturned() {
+        //arrange
+
+        //act
+        ResponseEntity<String> courseStatusResponse =
+                template.getForEntity(
+                        "/session/user/1/course/1/state",
+                        String.class);
+
+        //assert
+        assertNotNull(courseStatusResponse);
+        assertEquals(HttpStatus.NOT_FOUND, courseStatusResponse.getStatusCode());
+    }
+}

--- a/src/test/java/com/lginterview/integration/CourseRepositoryTests.java
+++ b/src/test/java/com/lginterview/integration/CourseRepositoryTests.java
@@ -1,0 +1,60 @@
+package com.lginterview.integration;
+
+import com.lginterview.entities.Course;
+import com.lginterview.entities.User;
+import com.lginterview.repositories.CourseRepository;
+import com.lginterview.repositories.UserRepository;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest
+public class CourseRepositoryTests {
+
+    @Autowired
+    private TestEntityManager entityManager;
+    @Autowired
+    private CourseRepository courseRepository;
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    public void Given_ExistingCourse_When_getCourse_Then_CourseIsReturned() {
+        //arrange
+        User user = userRepository.findOne(1L);
+        Course course = new Course();
+        course.setCourseUser(user);
+        long newCourseId = entityManager.persist(course).getId();
+
+        //act
+        Optional<Course> foundCourse = courseRepository.getCourse(user.getId(), newCourseId);
+
+        //assert
+        assertTrue(foundCourse.isPresent());
+        assertEquals(user, foundCourse.get().getCourseUser());
+        assertEquals(newCourseId, foundCourse.get().getId());
+    }
+
+    @Test
+    public void Given_NotExistingCourse_When_getCourse_Then_EmptyOptionalIsReturned() {
+        //arrange
+        User user = userRepository.findOne(1L);
+        //act
+        Optional<Course> foundCourse = courseRepository.getCourse(user.getId(), 1L);
+
+        //assert
+        assertFalse(foundCourse.isPresent());
+    }
+
+
+}

--- a/src/test/java/com/lginterview/providers/CourseProviderImplTest.java
+++ b/src/test/java/com/lginterview/providers/CourseProviderImplTest.java
@@ -1,0 +1,358 @@
+package com.lginterview.providers;
+
+import com.flextrade.jfixture.JFixture;
+import com.lginterview.dto.CourseRequest;
+import com.lginterview.dto.CourseStatus;
+import com.lginterview.dto.RequestType;
+import com.lginterview.entities.Course;
+import com.lginterview.entities.User;
+import com.lginterview.exceptions.CourseDataRetrievalException;
+import com.lginterview.repositories.CourseRepository;
+import com.lginterview.repositories.UserRepository;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+
+public class CourseProviderImplTest {
+
+    private final JFixture fixture = new JFixture();
+    private CourseRepository courseRepository;
+    private UserRepository userRepository;
+    private long userId;
+    private long courseId;
+    private long addedCourseId;
+    private ZonedDateTime courseStartTime;
+    private List<Integer> courseScore;
+
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setUp() throws Exception {
+        courseRepository = mock(CourseRepository.class);
+        userRepository = mock(UserRepository.class);
+        userId = fixture.create(Long.class);
+        courseId = fixture.create(Long.class);
+        addedCourseId = fixture.create(Long.class);
+        courseStartTime = ZonedDateTime.now();
+        courseScore = fixture.collections().createCollection(List.class, Integer.class);
+    }
+
+    @Test
+    public void Given_ValidNewCourseRequest_When_modifyCourse_Then_CourseIsAdded()
+            throws CourseDataRetrievalException {
+
+        //arrange
+        User mockUser = new User();
+        mockUser.setId(userId);
+        given(userRepository.findOne(userId)).willReturn(mockUser);
+        given(courseRepository.save(any(Course.class))).will(invocationOnMock -> {
+            Course courseArgument = invocationOnMock.getArgumentAt(0, Course.class);
+            courseArgument.setId(addedCourseId);
+            return courseArgument;
+        });
+
+        ArgumentCaptor<Course> courseArgumentCaptor = ArgumentCaptor.forClass(Course.class);
+
+        CourseRequest courseRequest = getCourseRequest(RequestType.INIT, null);
+        CourseProviderImpl courseProvider = new CourseProviderImpl(courseRepository, userRepository);
+
+        //act
+        long newCourseId = courseProvider.modifyCourse(courseRequest);
+
+        //assert
+        assertEquals(addedCourseId, newCourseId);
+        verify(courseRepository).save(courseArgumentCaptor.capture());
+        assertEquals(mockUser, courseArgumentCaptor.getValue().getCourseUser());
+        assertEquals(courseStartTime, courseArgumentCaptor.getValue().getStartDate());
+    }
+
+
+    @Test(expected = CourseDataRetrievalException.class)
+    public void Given_InValidNewCourseRequest_When_modifyCourse_Then_ExceptionIsThrown()
+            throws CourseDataRetrievalException {
+
+        //arrange
+        given(userRepository.findOne(userId)).willReturn(null);
+
+        CourseRequest courseRequest = getCourseRequest(RequestType.INIT, null);
+        CourseProviderImpl courseProvider = new CourseProviderImpl(courseRepository, userRepository);
+
+        //act
+        courseProvider.modifyCourse(courseRequest);
+    }
+
+
+    @Test
+    public void Given_ValidCourseSaveRequest_When_modifyCourse_Then_CourseIsAdded()
+            throws CourseDataRetrievalException {
+        //arrange
+        int courseScore = fixture.create(Integer.class);
+
+        Course courseToUpdate = new Course();
+        courseToUpdate.setId(courseId);
+        given(courseRepository.findOne(courseId)).willReturn(courseToUpdate);
+
+        given(courseRepository.save(any(Course.class))).will(invocationOnMock -> {
+            Course courseArgument = invocationOnMock.getArgumentAt(0, Course.class);
+            courseArgument.setId(addedCourseId);
+            return courseArgument;
+        });
+
+        ArgumentCaptor<Course> courseArgumentCaptor = ArgumentCaptor.forClass(Course.class);
+
+        CourseRequest courseRequest = getCourseRequest(RequestType.SAVE, courseScore);
+        CourseProviderImpl courseProvider = new CourseProviderImpl(courseRepository, userRepository);
+
+        //act
+        long newCourseId = courseProvider.modifyCourse(courseRequest);
+
+        //assert
+        assertEquals(addedCourseId, newCourseId);
+        verify(courseRepository).save(courseArgumentCaptor.capture());
+
+        List<Integer> scoreList = courseArgumentCaptor.getValue().getScores();
+        assertEquals(1, scoreList.size());
+        assertEquals(courseScore, scoreList.get(0).intValue());
+    }
+
+    @Test(expected = CourseDataRetrievalException.class)
+    public void Given_InValidCourseSaveRequest_When_modifyCourse_Then_ExceptionIsThrown()
+            throws CourseDataRetrievalException {
+
+        //arrange
+        int courseScore = fixture.create(Integer.class);
+
+        given(courseRepository.findOne(courseId)).willReturn(null);
+        given(courseRepository.save(any(Course.class))).will(invocationOnMock -> {
+            Course courseArgument = invocationOnMock.getArgumentAt(0, Course.class);
+            courseArgument.setId(addedCourseId);
+            return courseArgument;
+        });
+
+        CourseRequest courseRequest = getCourseRequest(RequestType.SAVE, courseScore);
+        CourseProviderImpl courseProvider = new CourseProviderImpl(courseRepository, userRepository);
+
+        //act
+        courseProvider.modifyCourse(courseRequest);
+    }
+
+    @Test
+    public void Given_ValidCourseFinishRequest_When_modifyCourse_Then_CourseIsAdded()
+            throws CourseDataRetrievalException {
+
+        //arrange
+        Course courseToClose = new Course();
+        courseToClose.setId(courseId);
+        given(courseRepository.findOne(courseId)).willReturn(courseToClose);
+
+        given(courseRepository.save(any(Course.class))).will(invocationOnMock -> {
+            Course courseArgument = invocationOnMock.getArgumentAt(0, Course.class);
+            courseArgument.setId(addedCourseId);
+            return courseArgument;
+        });
+
+        ArgumentCaptor<Course> courseArgumentCaptor = ArgumentCaptor.forClass(Course.class);
+
+        CourseRequest courseRequest = getCourseRequest(RequestType.FINISH, null);
+        CourseProviderImpl courseProvider = new CourseProviderImpl(courseRepository, userRepository);
+
+        //act
+        long newCourseId = courseProvider.modifyCourse(courseRequest);
+
+        //assert
+        assertEquals(addedCourseId, newCourseId);
+        verify(courseRepository).save(courseArgumentCaptor.capture());
+        assertEquals(courseStartTime, courseArgumentCaptor.getValue().getEndDate());
+
+    }
+
+    @Test(expected = CourseDataRetrievalException.class)
+    public void Given_InValidCourseFinishRequest_When_modifyCourse_Then_ExceptionIsThrown()
+            throws CourseDataRetrievalException {
+
+        //arrange
+        given(courseRepository.findOne(courseId)).willReturn(null);
+
+        given(courseRepository.save(any(Course.class))).will(invocationOnMock -> {
+            Course courseArgument = invocationOnMock.getArgumentAt(0, Course.class);
+            courseArgument.setId(addedCourseId);
+            return courseArgument;
+        });
+
+        CourseRequest courseRequest = getCourseRequest(RequestType.FINISH, null);
+        CourseProviderImpl courseProvider = new CourseProviderImpl(courseRepository, userRepository);
+
+        //act
+        courseProvider.modifyCourse(courseRequest);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void Given_NullCourseRequest_When_modifyCourse_Then_ExceptionIsThrown()
+            throws CourseDataRetrievalException {
+        //arrange
+
+        CourseProviderImpl courseProvider = new CourseProviderImpl(courseRepository, userRepository);
+
+        //act
+        courseProvider.modifyCourse(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void Given_NullTypedCourseRequest_When_modifyCourse_Then_ExceptionIsThrown()
+            throws CourseDataRetrievalException {
+
+        //arrange
+        CourseRepository courseRepository = mock(CourseRepository.class);
+        UserRepository userRepository = mock(UserRepository.class);
+
+        CourseProviderImpl courseProvider = new CourseProviderImpl(courseRepository, userRepository);
+
+        CourseRequest courseRequest =
+                getCourseRequest(null, null);
+
+        //act
+        courseProvider.modifyCourse(courseRequest);
+    }
+
+    @Test
+    public void Given_StartedCourseUserAndCourseId_When_getCourseStatus_Then_StartedCourseStatusIsReturned()
+            throws CourseDataRetrievalException {
+
+        //arrange
+        Course startedCourse = getCourse();
+        given(courseRepository.getCourse(userId, courseId)).willReturn(Optional.of(startedCourse));
+
+        CourseProviderImpl courseProvider = new CourseProviderImpl(courseRepository, userRepository);
+
+        CourseStatus expectedCourseStatus =
+                new CourseStatus(courseStartTime.withZoneSameInstant(ZoneId.of("UTC")),
+                        0,
+                        null,
+                        0,
+                        0);
+
+        //act
+        CourseStatus courseStatus = courseProvider.getCourseStatus(userId, courseId);
+
+        //assert
+        assertNotNull(courseStatus);
+        assertEquals(expectedCourseStatus, courseStatus);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void Given_SavedCourseUserAndCourseId_When_getCourseStatus_Then_SavedCourseStatusIsReturned()
+            throws CourseDataRetrievalException {
+        //arrange
+        int expectedBestScore = courseScore.stream().mapToInt(score -> score).max().orElse(0);
+        int expectedAverageScore = (int) courseScore.stream().mapToInt(score -> score).average().orElse(0.0);
+
+        Course savedCourse = getCourse();
+        savedCourse.getScores().addAll(courseScore);
+
+        given(courseRepository.getCourse(userId, courseId)).willReturn(Optional.of(savedCourse));
+
+        CourseStatus expectedCourseStatus =
+                new CourseStatus(courseStartTime.withZoneSameInstant(ZoneId.of("UTC")),
+                        0,
+                        null,
+                        expectedBestScore,
+                        expectedAverageScore);
+
+        CourseProviderImpl courseProvider = new CourseProviderImpl(courseRepository, userRepository);
+
+        //act
+        CourseStatus courseStatus = courseProvider.getCourseStatus(userId, courseId);
+
+        //assert
+        assertNotNull(courseStatus);
+        assertEquals(expectedCourseStatus, courseStatus);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void Given_FinishedCourseUserAndCourseId_When_getCourseStatus_Then_FinishedCourseStatusIsReturned()
+            throws CourseDataRetrievalException {
+
+        //arrange
+        ZonedDateTime courseEndTime = courseStartTime.plusMinutes(4);
+        Course finishedCourse = getCourse();
+        finishedCourse.getScores().addAll(courseScore);
+        finishedCourse.setEndDate(courseEndTime);
+        given(courseRepository.getCourse(userId, courseId)).willReturn(Optional.of(finishedCourse));
+
+        CourseStatus expectedCourseStatus = getCourseStatus(courseEndTime);
+        CourseProviderImpl courseProvider = new CourseProviderImpl(courseRepository, userRepository);
+
+        //act
+        CourseStatus courseStatus = courseProvider.getCourseStatus(userId, courseId);
+
+        //assert
+        assertNotNull(courseStatus);
+        assertEquals(expectedCourseStatus, courseStatus);
+    }
+
+    @Test(expected = CourseDataRetrievalException.class)
+    public void Given_InvalidCourseUserAndCourseId_When_getCourseStatus_Then_ExceptionIsThrown()
+            throws CourseDataRetrievalException {
+
+        //arrange
+        given(courseRepository.getCourse(userId, courseId)).willReturn(Optional.empty());
+
+        CourseProviderImpl courseProvider = new CourseProviderImpl(courseRepository, userRepository);
+
+        //act
+        courseProvider.getCourseStatus(userId, courseId);
+    }
+
+    private CourseStatus getCourseStatus(ZonedDateTime courseEndTime) {
+        int expectedBestScore = courseScore
+                .stream()
+                .mapToInt(score -> score)
+                .max()
+                .orElse(0);
+
+        int expectedAverageScore = (int) courseScore
+                .stream()
+                .mapToInt(score -> score)
+                .average()
+                .orElse(0.0);
+
+        int expectedCourseTime = (int) (courseEndTime.toEpochSecond() - courseStartTime.toEpochSecond());
+
+        return new CourseStatus(courseStartTime.withZoneSameInstant(ZoneId.of("UTC")),
+                expectedCourseTime,
+                courseEndTime.withZoneSameInstant(ZoneId.of("UTC")),
+                expectedBestScore,
+                expectedAverageScore);
+    }
+
+    private CourseRequest getCourseRequest(RequestType requestType, Integer score) {
+        return new CourseRequest(
+                userId,
+                courseId,
+                requestType,
+                score,
+                courseStartTime);
+    }
+
+    private Course getCourse() {
+        Course finishedCourse = new Course();
+        finishedCourse.setId(courseId);
+        finishedCourse.setStartDate(courseStartTime);
+        return finishedCourse;
+    }
+}


### PR DESCRIPTION
The post endpoint returns id of the created course - the same id should be used for updating and finishing the course
The status endpoint allows getting current course status:
- average and best scores will be returned after at least one score is saved
- end date and total time will be returned after course finish

The biggest score is considered best score

Service uses in-memory H2 database
File import.sql contains sample users with ids 1,2,3 to pre-populate database.
The parameter courseservice.limitation-count in application.properties sets the throttling threshold for requests throttling